### PR TITLE
feat: Agregar 1 día a la fecha de resumen en formatConferenceDate.ts

### DIFF
--- a/src/utils/functions/formatConferenceDate.ts
+++ b/src/utils/functions/formatConferenceDate.ts
@@ -45,6 +45,9 @@ export function getConferenceStatus(dates: ConferenceDates): ConferenceStatus {
   const conferenceEnd = new Date(dates['date-conference'].end)
   const summaryEnd = new Date(dates.summary.end)
 
+  // Agregar 1 día a summaryEnd
+  summaryEnd.setDate(summaryEnd.getDate() + 1)
+
   // Evaluaciones
   const isBeforeConference = dateNow < conferenceStart
   const isBeforeSummary = dateNow < summaryEnd

--- a/src/utils/functions/formatDate.ts
+++ b/src/utils/functions/formatDate.ts
@@ -4,28 +4,37 @@ type DateFormats =
   | 'MM/YYYY'
   | 'DD/MM/YYYY Hora: HH:mm'
 
-export function formatDate(dateString: string, format: DateFormats): string {
-  // Crear la fecha en UTC y ajustar a la zona horaria local
-  const dateParts = dateString.split('-')
-  const date = new Date(
-    parseInt(dateParts[0], 10), // Año
-    parseInt(dateParts[1], 10) - 1, // Mes (restar 1 ya que los meses en JS son 0-based)
-    parseInt(dateParts[2], 10) // Día
-  )
-
-  const day = String(date.getDate()).padStart(2, '0')
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const year = date.getFullYear()
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-
-  return format
-    .replace('DD', day)
-    .replace('MM', month)
-    .replace('YYYY', String(year))
-    .replace('HH', hours)
-    .replace('mm', minutes)
-}
+  export function formatDate(dateString: string, format: DateFormats): string {
+    // Dividir el dateString en partes
+    const [datePart, timePart] = dateString.split('T');
+    const dateParts = datePart.split('-');
+    
+    // Crear la fecha basada en el datePart
+    const year = parseInt(dateParts[0], 10);
+    const month = dateParts[1] ? parseInt(dateParts[1], 10) - 1 : 0; // Mes (restar 1 ya que los meses en JS son 0-based)
+    const day = dateParts[2] ? parseInt(dateParts[2], 10) : 1; // Si no hay día, asumir 1
+    const date = new Date(year, month, day);
+  
+    // Si el formato incluye horas, extraerlas o asignar valores predeterminados
+    let hours = '00', minutes = '00';
+    if (timePart) {
+      const [h, m] = timePart.split(':');
+      hours = h.padStart(2, '0');
+      minutes = m.padStart(2, '0');
+    }
+  
+    const dayString = String(date.getDate()).padStart(2, '0');
+    const monthString = String(date.getMonth() + 1).padStart(2, '0');
+    const yearString = String(date.getFullYear());
+  
+    // Devolver el formato solicitado
+    return format
+      .replace('DD', dayString)
+      .replace('MM', monthString)
+      .replace('YYYY', yearString)
+      .replace('HH', hours)
+      .replace('mm', minutes);
+  }
 
 export function formatDateLarge(dateString: string): string {
   const [year, month, day] = dateString.split('-').map(Number)


### PR DESCRIPTION
Refactorizar la función formatConferenceDate.ts para agregar 1 día a la fecha de resumen (summaryEnd) antes de realizar las evaluaciones. Esto asegura que las evaluaciones se realicen correctamente y no se omita ningún día importante.

fix: Corregir formato de fecha en formatDate.ts

Realizar cambios en la función formatDate.ts para corregir el formato de fecha. Ahora se divide correctamente el dateString en partes y se crea la fecha basada en el datePart. Además, se extraen las horas y minutos si están presentes en el formato solicitado.